### PR TITLE
removed links to defunct product/plans page

### DIFF
--- a/_includes/_new/_page-components/_footer-main.html
+++ b/_includes/_new/_page-components/_footer-main.html
@@ -44,7 +44,7 @@
                 <li class="--footer-column">
                     <h6 class="--footer-heading">Solutions</h6>&#x9;&#x9;&#x9;
                     <ul>
-                        <li><a href="https://plot.ly/product/plans/" target="_self">Plans &amp; Pricing</a></li>
+                        <li><a href="https://plot.ly/products/cloud/" target="_self">Plotly Cloud</a></li>
                         &#x9;&#x9;&#x9;&#x9;
                         <li><a href="https://plot.ly/product/enterprise/" target="_self">Enterprise</a></li>
                         &#x9;&#x9;&#x9;&#x9;

--- a/static/images/getting-data/Data integrations.html
+++ b/static/images/getting-data/Data integrations.html
@@ -372,7 +372,7 @@
 		<div class="two columns footcolumn respfooter">
 			<h6 class="footer-heading">Solutions</h6>
 			<ul>
-				<li><a href="https://plot.ly/product/plans/" target="_self">Plans &amp; Pricing</a></li>
+				<li><a href="https://plot.ly/products/cloud/" target="_self">Plotly Cloud</a></li>
 				<li><a href="https://plot.ly/product/enterprise/" target="_self">Enterprise</a></li>
 				<li><a href="https://plot.ly/online-graphing-and-statistics-for-educators/" target="_self">Education</a></li>
 				<li><a href="https://plot.ly/product/plotlyjs/" target="_self">Plotly.js</a></li>


### PR DESCRIPTION
The footers link to a now defunct page https://plot.ly/product/plans/

I've fixed this to link to the Plotly Cloud pricing page.