### PR TITLE
Changed footer to match plot.ly

### DIFF
--- a/_includes/_new/_page-components/_footer-main.html
+++ b/_includes/_new/_page-components/_footer-main.html
@@ -3,119 +3,73 @@
         <div class="--wrap">
             <ul class="--footer-body">
                 <li class="--footer-column">
-                    <h6 class="--footer-heading">API</h6>&#x9;&#x9;&#x9;
+                    <h6 class="--footer-heading">Developers</h6>&#x9;&#x9;&#x9;
                     <ul>
-                        <li><a href="https://plot.ly/api/" target="_self">Documentation</a></li>
+                        <li><a href="https://plot.ly/python/" target="_self">Python</a></li>
                         &#x9;&#x9;&#x9;&#x9;
-                        <li><a href="https://plot.ly/api/" target="_self">API Libraries</a></li>
+                        <li><a href="https://plot.ly/r/" target="_self">R & Shiny</a></li>
                         &#x9;&#x9;&#x9;&#x9;
-                        <li><a href="https://plot.ly/rest/" target="_self">REST APIs</a></li>
+                        <li><a href="https://plot.ly/matlab/" target="_self">MATLAB</a></li>
                         &#x9;&#x9;&#x9;&#x9;
-                        <li><a href="https://plot.ly/javascript/" target="_self">Plotly.js</a></li>
+                        <li><a href="https://plot.ly/javascript-graphing-library/" target="_self">Javascript</a></li>
                         &#x9;&#x9;&#x9;&#x9;
-                        <li><a href="https://plot.ly/workshop/" target="_self">Hardware</a></li>
+                        <li><a href="https://api.plot.ly/v2/" target="_self">REST API</a></li>
                     </ul>
                 </li>
                 &#x9;&#x9;
                 <li class="--footer-column">
-                    <h6 class="--footer-heading">About Us</h6>&#x9;&#x9;&#x9;
+                    <h6 class="--footer-heading">Company</h6>&#x9;&#x9;&#x9;
                     <ul>
-                        <li><a href="https://plot.ly/company/team/" target="_self">Team</a></li>
+                        <li><a href="https://plot.ly/company/careers/" target="_self">Careers</a></li>
                         &#x9;&#x9;&#x9;&#x9;
-                        <li><a href="https://plot.ly/company/jobs/" target="_self">Careers</a></li>
+                        <li><a href="https://blog.plot.ly/" target="_self">Blog</a></li>
                         &#x9;&#x9;&#x9;&#x9;
-                        <li><a href="http://blog.plot.ly" target="_blank">Plotly Blog</a></li>
+                        <li><a href="https://moderndata.plot.ly/" target="_blank">Modern Data</a></li>
                         &#x9;&#x9;&#x9;&#x9;
-                        <li><a href="http://moderndata.plot.ly" target="_blank">Modern Data</a></li>
+                        <li><a href="https://plot.ly/products/industries/" target="_blank">Industries</a></li>
+                        &#x9;&#x9;&#x9;&#x9;
+                        <li><a href="https://plotcon.plot.ly/" target="_blank">Workshops</a></li>
+                        &#x9;&#x9;&#x9;&#x9;
+                        <li><a href="https://plotly.typeform.com/to/r4OilH" target="_blank">Customer Contact</a></li>
                     </ul>
                 </li>
                 &#x9;&#x9;
                 <li class="--footer-column">
-                    <h6 class="--footer-heading">Help</h6>&#x9;&#x9;&#x9;
+                    <h6 class="--footer-heading">Resources</h6>&#x9;&#x9;&#x9;
                     <ul>
-                        <li><a href="https://plot.ly/learn/" target="_self">Knowledge Base</a></li>
+                        <li><a href="https://support.plot.ly/" target="_self">Developer Support</a></li>
                         &#x9;&#x9;&#x9;&#x9;
-                        <li><a href="https://plot.ly/benchmarks/" target="_self">Benchmarks</a></li>
+                        <li><a href="https://community.plot.ly/" target="_self">Community Support</a></li>
                         &#x9;&#x9;&#x9;&#x9;
-                        <li><a href="https://plot.ly/workshop/" target="_self">Workshop</a></li>
+                        <li><a href="http://help.plot.ly/" target="_self">Documentation</a></li>
                     </ul>
                 </li>
                 &#x9;&#x9;
                 <li class="--footer-column">
-                    <h6 class="--footer-heading">Solutions</h6>&#x9;&#x9;&#x9;
+                    <h6 class="--footer-heading">Data Science</h6>&#x9;&#x9;&#x9;
                     <ul>
-                        <li><a href="https://plot.ly/products/cloud/" target="_self">Plotly Cloud</a></li>
+                        <li><a href="https://plot.ly/dash/" target="_self">Dash</a></li>
                         &#x9;&#x9;&#x9;&#x9;
-                        <li><a href="https://plot.ly/product/enterprise/" target="_self">Enterprise</a></li>
+                        <li><a href="https://plot.ly/plotly-js-scientific-d3-charting-library/" target="_self">Plotly.js</a></li>
                         &#x9;&#x9;&#x9;&#x9;
-                        <li><a href="https://plot.ly/online-graphing-and-statistics-for-educators/" target="_self">Education</a>
+                        <li><a href="https://plot.ly/d3-js-for-python-and-pandas-charts/" target="_self">Plotly.py</a>
                         </li>
                         &#x9;&#x9;&#x9;&#x9;
-                        <li><a href="https://plot.ly/product/plotlyjs/" target="_self">Plotly.js</a></li>
+                        <li><a href="https://plot.ly/d3-js-for-r-and-shiny-charts/" target="_self">Plotly.R</a></li>
                     </ul>
                 </li>
                 &#x9;&#x9;
                 <li class="--footer-column">
-                    <h6 class="--footer-heading">Connect</h6>&#x9;&#x9;&#x9;
-                    <ul class="plotly-social-media-small">
-                        <li><a href="//twitter.com/plotlygraphs" target="_blank">
-                            <div class="icon">
-                                <svg style="width:24px;height:24px" viewBox="0 0 24 24">
-                                    <path fill="#000000"
-                                          d="M17.71,9.33C17.64,13.95 14.69,17.11 10.28,17.31C8.46,17.39 7.15,16.81 6,16.08C7.34,16.29 9,15.76 9.9,15C8.58,14.86 7.81,14.19 7.44,13.12C7.82,13.18 8.22,13.16 8.58,13.09C7.39,12.69 6.54,11.95 6.5,10.41C6.83,10.57 7.18,10.71 7.64,10.74C6.75,10.23 6.1,8.38 6.85,7.16C8.17,8.61 9.76,9.79 12.37,9.95C11.71,7.15 15.42,5.63 16.97,7.5C17.63,7.38 18.16,7.14 18.68,6.86C18.47,7.5 18.06,7.97 17.56,8.33C18.1,8.26 18.59,8.13 19,7.92C18.75,8.45 18.19,8.93 17.71,9.33M20,2H4A2,2 0 0,0 2,4V20A2,2 0 0,0 4,22H20A2,2 0 0,0 22,20V4C22,2.89 21.1,2 20,2Z"/>
-                                </svg>
-                            </div>
-                            <span>Twitter</span></a></li>
-                        <li>
-                            <a href="//www.instagram.com/plotly/" target="_blank">
-                                <div class="icon">
-                                    <svg style="width:24px;height:24px" viewBox="0 0 24 24">
-                                        <path fill="#000000" d="M20,6.5A0.5,0.5 0 0,1 19.5,7H17.5A0.5,0.5 0 0,1 17,6.5V4.5A0.5,0.5 0 0,1 17.5,4H19.5A0.5,0.5 0 0,1 20,4.5M4.5,20A0.5,0.5 0 0,1 4,19.5V11H6.09C6.03,11.32 6,11.66 6,12A6,6 0 0,0 12,18A6,6 0 0,0 18,12C18,11.66 17.96,11.32 17.91,11H20V19.5A0.5,0.5 0 0,1 19.5,20M12,8A4,4 0 0,1 16,12A4,4 0 0,1 12,16A4,4 0 0,1 8,12A4,4 0 0,1 12,8M20,2H4C2.89,2 2,2.89 2,4V20A2,2 0 0,0 4,22H20A2,2 0 0,0 22,20V4C22,2.89 21.1,2 20,2Z" />
-                                    </svg>
-                                </div>
-                                <span>Instagram</span></a>
+                    <h6 class="--footer-heading">Business Intelligence</h6>&#x9;&#x9;&#x9;
+                    <ul>
+                        <li><a href="https://plot.ly/online-chart-maker/" target="_self">Chart Studio</a></li>
+                        &#x9;&#x9;&#x9;&#x9;
+                        <li><a href="https://plot.ly/dashboards/" target="_self">Dashboards</a></li>
+                        &#x9;&#x9;&#x9;&#x9;
+                        <li><a href="https://plot.ly/powerpoint-online/" target="_self">Slide Decks</a>
                         </li>
-                        <li>
-                            <a href="//www.facebook.com/Plotly" target="_blank">
-                                <div class="icon">
-                                    <svg style="width:24px;height:24px" viewBox="0 0 24 24">
-                                        <path fill="#000000"
-                                              d="M19,4V7H17A1,1 0 0,0 16,8V10H19V13H16V20H13V13H11V10H13V7.5C13,5.56 14.57,4 16.5,4M20,2H4A2,2 0 0,0 2,4V20A2,2 0 0,0 4,22H20A2,2 0 0,0 22,20V4C22,2.89 21.1,2 20,2Z"/>
-                                    </svg>
-                                </div>
-                                <span>Facebook</span></a>
-                        </li>
-                        <li>
-                            <a href="//github.com/plotly" target="_blank">
-                                <div class="icon">
-                                    <svg style="width:24px;height:24px" viewBox="0 0 24 24">
-                                        <path fill="#000000"
-                                              d="M4,2H20A2,2 0 0,1 22,4V20A2,2 0 0,1 20,22H14.85C14.5,21.92 14.5,21.24 14.5,21V18.26C14.5,17.33 14.17,16.72 13.81,16.41C16.04,16.16 18.38,15.32 18.38,11.5C18.38,10.39 18,9.5 17.35,8.79C17.45,8.54 17.8,7.5 17.25,6.15C17.25,6.15 16.41,5.88 14.5,7.17C13.71,6.95 12.85,6.84 12,6.84C11.15,6.84 10.29,6.95 9.5,7.17C7.59,5.88 6.75,6.15 6.75,6.15C6.2,7.5 6.55,8.54 6.65,8.79C6,9.5 5.62,10.39 5.62,11.5C5.62,15.31 7.95,16.17 10.17,16.42C9.89,16.67 9.63,17.11 9.54,17.76C8.97,18 7.5,18.45 6.63,16.93C6.63,16.93 6.1,15.97 5.1,15.9C5.1,15.9 4.12,15.88 5,16.5C5,16.5 5.68,16.81 6.14,17.97C6.14,17.97 6.73,19.91 9.5,19.31V21C9.5,21.24 9.5,21.92 9.14,22H4A2,2 0 0,1 2,20V4A2,2 0 0,1 4,2Z"/>
-                                    </svg>
-                                </div>
-                                <span>Github</span></a></li>
-                        <li>
-                            <a href="//linkedin.com/company/plotly" target="_blank">
-                                <div class="icon">
-                                    <svg style="width:24px;height:24px" viewBox="0 0 24 24">
-                                        <path fill="#000000"
-                                              d="M19,19H16V13.7A1.5,1.5 0 0,0 14.5,12.2A1.5,1.5 0 0,0 13,13.7V19H10V10H13V11.2C13.5,10.36 14.59,9.8 15.5,9.8A3.5,3.5 0 0,1 19,13.3M6.5,8.31C5.5,8.31 4.69,7.5 4.69,6.5A1.81,1.81 0 0,1 6.5,4.69C7.5,4.69 8.31,5.5 8.31,6.5A1.81,1.81 0 0,1 6.5,8.31M8,19H5V10H8M20,2H4C2.89,2 2,2.89 2,4V20A2,2 0 0,0 4,22H20A2,2 0 0,0 22,20V4C22,2.89 21.1,2 20,2Z"/>
-                                    </svg>
-                                </div>
-                                <span>LinkedIn</span>
-                            </a>
-                        </li>
-                        <li>
-                            <a href="//plus.google.com/+PlotLy" target="_blank">
-                                <div class="icon">
-                                    <svg style="width:24px;height:24px" viewBox="0 0 24 24">
-                                        <path fill="#000000"
-                                              d="M20,2A2,2 0 0,1 22,4V20A2,2 0 0,1 20,22H4A2,2 0 0,1 2,20V4C2,2.89 2.9,2 4,2H20M20,12H18V10H17V12H15V13H17V15H18V13H20V12M9,11.29V13H11.86C11.71,13.71 11,15.14 9,15.14C7.29,15.14 5.93,13.71 5.93,12C5.93,10.29 7.29,8.86 9,8.86C10,8.86 10.64,9.29 11,9.64L12.36,8.36C11.5,7.5 10.36,7 9,7C6.21,7 4,9.21 4,12C4,14.79 6.21,17 9,17C11.86,17 13.79,15 13.79,12.14C13.79,11.79 13.79,11.57 13.71,11.29H9Z"/>
-                                    </svg>
-                                </div>
-                                <span>Google+</span>
-                            </a>
-                        </li>
+                        &#x9;&#x9;&#x9;&#x9;
+                        <li><a href="https://marketing.plot.ly/database-connectors/" target="_self">Falcon SQL Client (Free)</a></li>
                     </ul>
                 </li>
             </ul>
@@ -124,7 +78,7 @@
     <section class="--footer-meta">
         <div class="--wrap">
             <div class="left">
-                <article class="--copyright">Copyright &copy; 2015 Plotly. All rights reserved.</article>
+                <article class="--copyright">Copyright &copy; 2018 Plotly. All rights reserved.</article>
             </div>
             <div class="right">
                 <article class="--tos"><a href="https://plot.ly/terms-of-service/" target="_blank">Terms of Service</a>

--- a/_includes/new_footer.html
+++ b/_includes/new_footer.html
@@ -1,65 +1,93 @@
-
-<footer>
-	<div class="row footerarea footer-top">
-		<div class="one column footcolumn space"> </div>
-		<div class="two columns footcolumn respfooter">
-			<h6 class="footer-heading">API</h6>
-			<ul>
-				<li><a  href="https://plot.ly/api/" target="_self">Documentation</a></li>
-				<li><a  href="https://plot.ly/api/" target="_self">API Libraries</a></li>
-				<li><a  href="https://plot.ly/rest/" target="_self">REST APIs</a></li>
-				<li><a  href="https://plot.ly/javascript-graphing-library/" target="_self">Plotly.js</a></li>
-				<li><a  href="https://plot.ly/workshop/" target="_self">Hardware</a></li>
-			</ul>
-		</div>
-		<div class="two columns footcolumn respfooter">
-			<h6 class="footer-heading">About Us</h6>
-			<ul>
-				<li><a href="https://plot.ly/company/team/" target="_self">Team</a></li>
-				<li><a href="https://plot.ly/company/jobs/" target="_self">Careers</a></li>
-				<li><a href="http://blog.plot.ly" target="_blank">Plotly Blog</a></li>
-				<li><a href="http://moderndata.plot.ly" target="_blank">Modern Data</a></li>
-			</ul>
-		</div>
-		<div class="two columns footcolumn respfooter">
-			<h6 class="footer-heading">Help</h6>
-			<ul>
-				<li><a href="https://plot.ly/learn/" target="_self">Knowledge Base</a></li>
-				<li><a href="https://plot.ly/benchmarks/" target="_self">Benchmarks</a></li>
-				<li><a href="https://plot.ly/workshop/" target="_self">Workshop</a></li>
-			</ul>
-		</div>
-		<div class="two columns footcolumn respfooter">
-			<h6 class="footer-heading">Solutions</h6>
-			<ul>
-				<li><a href="https://plot.ly/product/plans/" target="_self">Plans &amp; Pricing</a></li>
-				<li><a href="https://plot.ly/product/enterprise/" target="_self">Enterprise</a></li>
-				<li><a href="https://plot.ly/online-graphing-and-statistics-for-educators/" target="_self">Education</a></li>
-				<li><a href="https://plot.ly/product/plotlyjs/" target="_self">Plotly.js</a></li>
-			</ul>
-		</div>
-		<div class="two columns footcolumn respfooter">
-     		<h6 class="footer-heading">Connect</h6>
-			<ul class="plotly-social-media-small">
-				<li><a href="//twitter.com/plotlygraphs" target="_blank"><i class="icon-twitter social_icon"></i></a></li>
-				<li><a href="//www.facebook.com/Plotly" target="_blank"><i class="icon-facebook social_icon"></i></a></li>
-				<li><a href="//github.com/plotly" target="_blank"><i class="icon-github social_icon"></i></a></li>
-				<li><a href="//linkedin.com/company/plotly" target="_blank"><i class="icon-linkedin social_icon"></i></a></li>
-				<li><a href="//plus.google.com/+PlotLy" target="_blank"><i class="icon-google-plus  social_icon"></i></a></li>
-			</ul>
-		</div>
-		<div class="one column footcolumn"></div>
-	</div>
-
-	<div class="row footerarea footer-bottom">
-		<div class="one column footcolumn space"> </div>
-		<div class="four columns footcolumn"><p>Copyright &copy; 2015 Plotly. All rights reserved.</p></div>
-		<div class="two columns footcolumn"><a href="https://plot.ly/terms-of-service/" target="_blank" ><p>Terms of Service</p></a></div>
-		<div class="two columns footcolumn"><a href="https://plot.ly/privacy/" target="_blank"><p>Privacy Policy</p></a></div>
-
-
-	</div>
-
+<footer class="--footer-main">
+    <section class="--footer-top">
+        <div class="--wrap">
+            <ul class="--footer-body">
+                <li class="--footer-column">
+                    <h6 class="--footer-heading">Developers</h6>&#x9;&#x9;&#x9;
+                    <ul>
+                        <li><a href="https://plot.ly/python/" target="_self">Python</a></li>
+                        &#x9;&#x9;&#x9;&#x9;
+                        <li><a href="https://plot.ly/r/" target="_self">R & Shiny</a></li>
+                        &#x9;&#x9;&#x9;&#x9;
+                        <li><a href="https://plot.ly/matlab/" target="_self">MATLAB</a></li>
+                        &#x9;&#x9;&#x9;&#x9;
+                        <li><a href="https://plot.ly/javascript-graphing-library/" target="_self">Javascript</a></li>
+                        &#x9;&#x9;&#x9;&#x9;
+                        <li><a href="https://api.plot.ly/v2/" target="_self">REST API</a></li>
+                    </ul>
+                </li>
+                &#x9;&#x9;
+                <li class="--footer-column">
+                    <h6 class="--footer-heading">Company</h6>&#x9;&#x9;&#x9;
+                    <ul>
+                        <li><a href="https://plot.ly/company/careers/" target="_self">Careers</a></li>
+                        &#x9;&#x9;&#x9;&#x9;
+                        <li><a href="https://blog.plot.ly/" target="_self">Blog</a></li>
+                        &#x9;&#x9;&#x9;&#x9;
+                        <li><a href="https://moderndata.plot.ly/" target="_blank">Modern Data</a></li>
+                        &#x9;&#x9;&#x9;&#x9;
+                        <li><a href="https://plot.ly/products/industries/" target="_blank">Industries</a></li>
+                        &#x9;&#x9;&#x9;&#x9;
+                        <li><a href="https://plotcon.plot.ly/" target="_blank">Workshops</a></li>
+                        &#x9;&#x9;&#x9;&#x9;
+                        <li><a href="https://plotly.typeform.com/to/r4OilH" target="_blank">Customer Contact</a></li>
+                    </ul>
+                </li>
+                &#x9;&#x9;
+                <li class="--footer-column">
+                    <h6 class="--footer-heading">Resources</h6>&#x9;&#x9;&#x9;
+                    <ul>
+                        <li><a href="https://support.plot.ly/" target="_self">Developer Support</a></li>
+                        &#x9;&#x9;&#x9;&#x9;
+                        <li><a href="https://community.plot.ly/" target="_self">Community Support</a></li>
+                        &#x9;&#x9;&#x9;&#x9;
+                        <li><a href="http://help.plot.ly/" target="_self">Documentation</a></li>
+                    </ul>
+                </li>
+                &#x9;&#x9;
+                <li class="--footer-column">
+                    <h6 class="--footer-heading">Data Science</h6>&#x9;&#x9;&#x9;
+                    <ul>
+                        <li><a href="https://plot.ly/dash/" target="_self">Dash</a></li>
+                        &#x9;&#x9;&#x9;&#x9;
+                        <li><a href="https://plot.ly/plotly-js-scientific-d3-charting-library/" target="_self">Plotly.js</a></li>
+                        &#x9;&#x9;&#x9;&#x9;
+                        <li><a href="https://plot.ly/d3-js-for-python-and-pandas-charts/" target="_self">Plotly.py</a>
+                        </li>
+                        &#x9;&#x9;&#x9;&#x9;
+                        <li><a href="https://plot.ly/d3-js-for-r-and-shiny-charts/" target="_self">Plotly.R</a></li>
+                    </ul>
+                </li>
+                &#x9;&#x9;
+                <li class="--footer-column">
+                    <h6 class="--footer-heading">Business Intelligence</h6>&#x9;&#x9;&#x9;
+                    <ul>
+                        <li><a href="https://plot.ly/online-chart-maker/" target="_self">Chart Studio</a></li>
+                        &#x9;&#x9;&#x9;&#x9;
+                        <li><a href="https://plot.ly/dashboards/" target="_self">Dashboards</a></li>
+                        &#x9;&#x9;&#x9;&#x9;
+                        <li><a href="https://plot.ly/powerpoint-online/" target="_self">Slide Decks</a>
+                        </li>
+                        &#x9;&#x9;&#x9;&#x9;
+                        <li><a href="https://marketing.plot.ly/database-connectors/" target="_self">Falcon SQL Client (Free)</a></li>
+                    </ul>
+                </li>
+            </ul>
+        </div>
+    </section>
+    <section class="--footer-meta">
+        <div class="--wrap">
+            <div class="left">
+                <article class="--copyright">Copyright &copy; 2018 Plotly. All rights reserved.</article>
+            </div>
+            <div class="right">
+                <article class="--tos"><a href="https://plot.ly/terms-of-service/" target="_blank">Terms of Service</a>
+                </article>
+                <article class="--privacy"><a href="https://plot.ly/privacy/" target="_blank">Privacy Policy</a>
+                </article>
+            </div>
+        </div>
+    </section>
 </footer>
 
 

--- a/index.html
+++ b/index.html
@@ -69,7 +69,7 @@ title: Plotly Help Center
                                 <div class="category-img"><img src="https://s3-us-west-1.amazonaws.com/plotly-tutorials/background-images/python-logo.png" alt="">
                                 </div>
                                 <div class="category-meta">
-                                    <h2>API Clients</h2>
+                                    <h2>Open-Source Graphing Libraries</h2>
                                     <p>Engineers and data scientists using Python, R, Matlab or Javascript.</p>
                                 </div>
                             </div>

--- a/static/images/getting-data/Data integrations.html
+++ b/static/images/getting-data/Data integrations.html
@@ -339,67 +339,96 @@
 
   </div>
   
-<footer>
-	<div class="row footerarea footer-top">
-		<div class="one column footcolumn space"> </div>
-		<div class="two columns footcolumn respfooter">
-			<h6 class="footer-heading">API</h6>
-			<ul>
-				<li><a href="https://plot.ly/api/" target="_self">Documentation</a></li>
-				<li><a href="https://plot.ly/api/" target="_self">API Libraries</a></li>
-				<li><a href="https://plot.ly/rest/" target="_self">REST APIs</a></li>
-				<li><a href="https://plot.ly/javascript-graphing-library/" target="_self">Plotly.js</a></li>
-				<li><a href="https://plot.ly/workshop/" target="_self">Hardware</a></li>
-			</ul>
-		</div>
-		<div class="two columns footcolumn respfooter">
-			<h6 class="footer-heading">About Us</h6>
-			<ul>
-				<li><a href="https://plot.ly/company/team/" target="_self">Team</a></li>
-				<li><a href="https://plot.ly/company/jobs/" target="_self">Careers</a></li>
-				<li><a href="http://blog.plot.ly/" target="_blank">Plotly Blog</a></li>
-				<li><a href="http://moderndata.plot.ly/" target="_blank">Modern Data</a></li>
-			</ul>
-		</div>
-		<div class="two columns footcolumn respfooter">
-			<h6 class="footer-heading">Help</h6>
-			<ul>
-				<li><a href="https://plot.ly/learn/" target="_self">Knowledge Base</a></li>
-				<li><a href="https://plot.ly/benchmarks/" target="_self">Benchmarks</a></li>
-				<li><a href="https://plot.ly/workshop/" target="_self">Workshop</a></li>
-			</ul>
-		</div>
-		<div class="two columns footcolumn respfooter">
-			<h6 class="footer-heading">Solutions</h6>
-			<ul>
-				<li><a href="https://plot.ly/products/cloud/" target="_self">Plotly Cloud</a></li>
-				<li><a href="https://plot.ly/product/enterprise/" target="_self">Enterprise</a></li>
-				<li><a href="https://plot.ly/online-graphing-and-statistics-for-educators/" target="_self">Education</a></li>
-				<li><a href="https://plot.ly/product/plotlyjs/" target="_self">Plotly.js</a></li>
-			</ul>
-		</div>
-		<div class="two columns footcolumn respfooter">	
-     		<h6 class="footer-heading">Connect</h6>
-			<ul class="plotly-social-media-small">
-				<li><a href="http://twitter.com/plotlygraphs" target="_blank"><i class="icon-twitter social_icon"></i></a></li>
-				<li><a href="http://www.facebook.com/Plotly" target="_blank"><i class="icon-facebook social_icon"></i></a></li>
-				<li><a href="http://github.com/plotly" target="_blank"><i class="icon-github social_icon"></i></a></li>
-				<li><a href="http://linkedin.com/company/plotly" target="_blank"><i class="icon-linkedin social_icon"></i></a></li>
-				<li><a href="http://plus.google.com/+PlotLy" target="_blank"><i class="icon-google-plus  social_icon"></i></a></li>
-			</ul>
-		</div>
-		<div class="one column footcolumn"></div>
-	</div>
-	
-	<div class="row footerarea footer-bottom">
-		<div class="one column footcolumn space"> </div>
-		<div class="four columns footcolumn"><p>Copyright © 2015 Plotly. All rights reserved.</p></div>
-		<div class="two columns footcolumn"><a href="https://plot.ly/terms-of-service/" target="_blank"><p>Terms of Service</p></a></div>
-		<div class="two columns footcolumn"><a href="https://plot.ly/privacy/" target="_blank"><p>Privacy Policy</p></a></div>
-		
-		
-	</div>
-
+  <footer class="--footer-main">
+    <section class="--footer-top">
+        <div class="--wrap">
+            <ul class="--footer-body">
+                <li class="--footer-column">
+                    <h6 class="--footer-heading">Developers</h6>&#x9;&#x9;&#x9;
+                    <ul>
+                        <li><a href="https://plot.ly/python/" target="_self">Python</a></li>
+                        &#x9;&#x9;&#x9;&#x9;
+                        <li><a href="https://plot.ly/r/" target="_self">R & Shiny</a></li>
+                        &#x9;&#x9;&#x9;&#x9;
+                        <li><a href="https://plot.ly/matlab/" target="_self">MATLAB</a></li>
+                        &#x9;&#x9;&#x9;&#x9;
+                        <li><a href="https://plot.ly/javascript-graphing-library/" target="_self">Javascript</a></li>
+                        &#x9;&#x9;&#x9;&#x9;
+                        <li><a href="https://api.plot.ly/v2/" target="_self">REST API</a></li>
+                    </ul>
+                </li>
+                &#x9;&#x9;
+                <li class="--footer-column">
+                    <h6 class="--footer-heading">Company</h6>&#x9;&#x9;&#x9;
+                    <ul>
+                        <li><a href="https://plot.ly/company/careers/" target="_self">Careers</a></li>
+                        &#x9;&#x9;&#x9;&#x9;
+                        <li><a href="https://blog.plot.ly/" target="_self">Blog</a></li>
+                        &#x9;&#x9;&#x9;&#x9;
+                        <li><a href="https://moderndata.plot.ly/" target="_blank">Modern Data</a></li>
+                        &#x9;&#x9;&#x9;&#x9;
+                        <li><a href="https://plot.ly/products/industries/" target="_blank">Industries</a></li>
+                        &#x9;&#x9;&#x9;&#x9;
+                        <li><a href="https://plotcon.plot.ly/" target="_blank">Workshops</a></li>
+                        &#x9;&#x9;&#x9;&#x9;
+                        <li><a href="https://plotly.typeform.com/to/r4OilH" target="_blank">Customer Contact</a></li>
+                    </ul>
+                </li>
+                &#x9;&#x9;
+                <li class="--footer-column">
+                    <h6 class="--footer-heading">Resources</h6>&#x9;&#x9;&#x9;
+                    <ul>
+                        <li><a href="https://support.plot.ly/" target="_self">Developer Support</a></li>
+                        &#x9;&#x9;&#x9;&#x9;
+                        <li><a href="https://community.plot.ly/" target="_self">Community Support</a></li>
+                        &#x9;&#x9;&#x9;&#x9;
+                        <li><a href="http://help.plot.ly/" target="_self">Documentation</a></li>
+                    </ul>
+                </li>
+                &#x9;&#x9;
+                <li class="--footer-column">
+                    <h6 class="--footer-heading">Data Science</h6>&#x9;&#x9;&#x9;
+                    <ul>
+                        <li><a href="https://plot.ly/dash/" target="_self">Dash</a></li>
+                        &#x9;&#x9;&#x9;&#x9;
+                        <li><a href="https://plot.ly/plotly-js-scientific-d3-charting-library/" target="_self">Plotly.js</a></li>
+                        &#x9;&#x9;&#x9;&#x9;
+                        <li><a href="https://plot.ly/d3-js-for-python-and-pandas-charts/" target="_self">Plotly.py</a>
+                        </li>
+                        &#x9;&#x9;&#x9;&#x9;
+                        <li><a href="https://plot.ly/d3-js-for-r-and-shiny-charts/" target="_self">Plotly.R</a></li>
+                    </ul>
+                </li>
+                &#x9;&#x9;
+                <li class="--footer-column">
+                    <h6 class="--footer-heading">Business Intelligence</h6>&#x9;&#x9;&#x9;
+                    <ul>
+                        <li><a href="https://plot.ly/online-chart-maker/" target="_self">Chart Studio</a></li>
+                        &#x9;&#x9;&#x9;&#x9;
+                        <li><a href="https://plot.ly/dashboards/" target="_self">Dashboards</a></li>
+                        &#x9;&#x9;&#x9;&#x9;
+                        <li><a href="https://plot.ly/powerpoint-online/" target="_self">Slide Decks</a>
+                        </li>
+                        &#x9;&#x9;&#x9;&#x9;
+                        <li><a href="https://marketing.plot.ly/database-connectors/" target="_self">Falcon SQL Client (Free)</a></li>
+                    </ul>
+                </li>
+            </ul>
+        </div>
+    </section>
+    <section class="--footer-meta">
+        <div class="--wrap">
+            <div class="left">
+                <article class="--copyright">Copyright &copy; 2018 Plotly. All rights reserved.</article>
+            </div>
+            <div class="right">
+                <article class="--tos"><a href="https://plot.ly/terms-of-service/" target="_blank">Terms of Service</a>
+                </article>
+                <article class="--privacy"><a href="https://plot.ly/privacy/" target="_blank">Privacy Policy</a>
+                </article>
+            </div>
+        </div>
+    </section>
 </footer>
 
 


### PR DESCRIPTION
in response to issue https://github.com/plotly/documentation/issues/1055

changed the footer across help.plot.ly to match footer on plot.ly. 

Also, relabeled API Clients to Open-Source Graphing Libraries, as suggested in https://github.com/plotly/streambed/issues/11342.