### PR TITLE
Minor HTML5 and CSS fixes. Order gems. Fix case of Python. Remove whitespace.

### DIFF
--- a/404.html
+++ b/404.html
@@ -16,7 +16,6 @@ title: 404 Page
           <link rel="stylesheet" type="text/css" href="{{site.staticurl}}css/plotly_icons.css">
           <link href="//fonts.googleapis.com/css?family=Open+Sans:600,400,300,200|Inconsolata|Ubuntu+Mono:400,700" rel="stylesheet" type="text/css">
 
-
 	<!-- Stylesheets -->
 	  <link rel="stylesheet" type="text/css" href="{{site.staticurl}}css/main.css">
 	  <link rel="stylesheet" type="text/css" href="{{site.staticurl}}css/normalize.css">
@@ -25,10 +24,7 @@ title: 404 Page
 	  <link rel="stylesheet" type="text/css" href="{{site.staticurl}}css/modules.css">
 	  <link rel="stylesheet" type="text/css" href="{{site.staticurl}}css/state.css">
 
-
-
     </head>
-
 
   {% include new_header.html %}
   <body>
@@ -37,14 +33,12 @@ title: 404 Page
   	<div class="sectionseparator_a">
 	  	<div class="bigcontainer">
 	  		<h1 class="centered">404 - Page not found</h1>
-	  		<h6 class="centered">Oops! It looks like this page doesn't exist.</br>Check the URL for errors or try refreshing the page.</h6>
+	  		<h6 class="centered">Oops! It looks like this page doesn't exist.<br>Check the URL for errors or try refreshing the page.</h6>
 	  	<img style="width: 200px;" alt="Plotly logo" src="{{site.staticurl}}/images/plotly-hist-logo_250w.png">
 	  	</div>
   	</div>
 
   {% include new_footer.html %}
-
-
 
 </body>
 </html>

--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,6 @@ gem 'percy-cli'
 
 group :jekyll_plugins do
   gem 'algoliasearch-jekyll'
-  gem 'jekyll-sitemap'
   gem 'jekyll-redirect-from'
+  gem 'jekyll-sitemap'
 end

--- a/_includes/_new/_page-components/_footer-main.html
+++ b/_includes/_new/_page-components/_footer-main.html
@@ -49,10 +49,7 @@
                             &#x9;&#x9;&#x9;&#x9;
                             <li>
                               <p class="subscribe-text"> Sign up to stay in the loop with all things Plotly — from Dash Club to product updates, webinars, and more!</p>
-                              <a 
-                                href="https://go.plot.ly/subscription" 
-                                class="subscribe-button" 
-                                target="_blank">
+                              <a href="https://go.plot.ly/subscription" class="subscribe-button" target="_blank">
                                 Subscribe
                               </a>
                             </li>

--- a/_includes/_new/_page-components/_header-main.html
+++ b/_includes/_new/_page-components/_header-main.html
@@ -1,14 +1,15 @@
 <header data-spy="affix" data-offset-top="80" class="header-main --default">
     <div class="--wrap">
         <div class="--wrap-left"><a href="https://plot.ly/" target="_blank" class="-identity">
-            <img  src="https://prismic-io.s3.amazonaws.com/plotly%2F6ea9b995-cdd8-49cb-b058-38bd44c1982d_plotly-logo-01-stripe%402x.png"/></a>
+            <img src="https://prismic-io.s3.amazonaws.com/plotly%2F6ea9b995-cdd8-49cb-b058-38bd44c1982d_plotly-logo-01-stripe%402x.png"></a>
         </div>
         <div class="--wrap-right">
             <nav class="--nav-meta" role="navigation">
                 <ul>
                     <li><a href="https://go.plot.ly/live_demo" data-mode="1" target="_blank" class="typeform-share button --enterprise-quaternary">
                         DEMO
-                        DASH</a></li>
+                        DASH</a>
+                    </li>
                 </ul>
             </nav>
         </div>

--- a/_includes/_new/_page-components/_seo.html
+++ b/_includes/_new/_page-components/_seo.html
@@ -26,4 +26,3 @@
 
 {% include google-tag-head.html %}
 {% include drift-tag.html %}
-

--- a/_includes/breadcrumb.html
+++ b/_includes/breadcrumb.html
@@ -17,5 +17,3 @@
 		<paper-ripple fit></paper-ripple>
 	</a>
 </div>
-
-

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,34 +1,22 @@
 <!DOCTYPE html>
 <html>
   <head>
-
-
     {% include google-tag-head.html %}
     {% include drift-tag.html %}
 
     <!-- META TAGS -->
     {% include seo.html %}
-    <meta charset="utf-8" />
-    <meta http-equiv="X-UA-Compatible" content="chrome=1" />
-    <meta
-      name="viewport"
-      content="width=device-width, initial-scale=1, maximum-scale=1"
-    />
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="chrome=1">
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
 
     <!-- Stylesheets -->
-    <link
-      rel="stylesheet"
-      type="text/css"
-      href="https://images.plot.ly/assets/css/normalize.css"
-    />
-    <link rel="stylesheet" type="text/css" href="{{ site.stylesheet }}" />
+    <link rel="stylesheet" type="text/css" href="https://images.plot.ly/assets/css/normalize.css">
+    <link rel="stylesheet" type="text/css" href="{{ site.stylesheet }}">
 
     <script src="//ajax.googleapis.com/ajax/libs/jquery/2.2.0/jquery.min.js"></script>
-    <script
-      src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/js/bootstrap.min.js"
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/js/bootstrap.min.js"
       integrity="sha384-0mSbJDEHialfmuBBQP6A4Qrprq5OVfW37PRR3j5ELqxss1yVqOtnepnHVP9aJ7xS"
-      crossorigin="anonymous"
-    ></script>
-
+      crossorigin="anonymous"></script>
   </head>
 </html>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -2,7 +2,6 @@
     {% include google-tag-head.html %}
     {% include drift-tag.html %}
 
-
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="chrome=1">
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
@@ -33,7 +32,6 @@
     <meta name="twitter:site" content="@plotlygraphs">
     <!--/ twitter tags -->
 
-
     <link rel="stylesheet" type="text/css" href="/stylesheets/pygment_trac.css" media="screen">
     <link rel="stylesheet" type="text/css" href="/stylesheets/print.css" media="print">
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.4.0/css/font-awesome.min.css">
@@ -45,4 +43,3 @@
 
     <title>{{page.title}}</title>
 </head>
-

--- a/_includes/help-box.html
+++ b/_includes/help-box.html
@@ -1,14 +1,8 @@
 <section class="--help-box">
-  <a
-    href="https://dash.plot.ly/getting-started
-  "
-    ><div class="--wrap">
+  <a href="https://dash.plot.ly/getting-started">
+    <div class="--wrap">
       <div class="--body">
-        <img
-          height="50%"
-          width="50%"
-          src="https://s3-us-west-1.amazonaws.com/plotly-tutorials/assets/dash-ad.png"
-        />
+        <img height="50%" width="50%" src="https://s3-us-west-1.amazonaws.com/plotly-tutorials/assets/dash-ad.png">
       </div>
     </div>
   </a>

--- a/_includes/hero.html
+++ b/_includes/hero.html
@@ -21,6 +21,6 @@
         {% endif %}
         {% endfor %}
     </div>
-    <br clear="both" />
+    <br clear="both">
     <!-- </div> -->
 </div>

--- a/_includes/new_footer.html
+++ b/_includes/new_footer.html
@@ -79,7 +79,6 @@
     </section>
 </footer>
 
-
 <script type="text/x-mathjax-config">
 MathJax.Hub.Config({tex2jax: {inlineMath: [['$','$'], ['\\(','\\)']], processEscapes: true}});
 </script>
@@ -123,7 +122,6 @@ function getQueryParam(param) {
 				"email_campaign_received": visit_origin
 		});
 </script>
-
 
 <script type="text/javascript">
 setTimeout(function(){var a=document.createElement("script");

--- a/_includes/new_header.html
+++ b/_includes/new_header.html
@@ -38,8 +38,6 @@
 
   </div>
 
-
-
   <div class="hamburger">
     <a href="#popmenufull" onclick="return clickfullmenu();">
       <img src="http://i.imgur.com/o7Mxj6T.png" alt="Menu" id="hamburgerlink" onmouseover="this.src='http://i.imgur.com/gj2TtuI.png'" onmouseout="this.src='http://i.imgur.com/o7Mxj6T.png'">

--- a/_includes/scripts-index.html
+++ b/_includes/scripts-index.html
@@ -29,7 +29,6 @@ $('document').ready(function() {
                     callback: function(toggle, anchor) {} // Function to run after scrolling
                 });
 
-
                 var aChildren = $(".sidebar ul li").children(); // find the a children of the list items
                 var aArray = []; // create the empty aArray
                 for (var i = 0; i < aChildren.length; i++) {

--- a/_includes/scripts-tutorial-single.html
+++ b/_includes/scripts-tutorial-single.html
@@ -9,7 +9,6 @@ $('document').ready(function() {
         callback: function(toggle, anchor) {} // Function to run after scrolling
     });
 
-
     var aChildren = $(".steps ul li").children(); // find the a children of the list items
     var aArray = []; // create the empty aArray
     for (var i = 0; i < aChildren.length; i++) {
@@ -47,16 +46,13 @@ $('document').ready(function() {
         }
     });
 
-
     $(window).scroll(function() {
         var length = $('main .wrap').position().top + $('main .wrap').outerHeight(true);
         var helpH = $('main .help-box').outerHeight(true);
         var tlt = $('main .tutorials-like-this').outerHeight(true);
         var bottom = (helpH + tlt)-11;
 
-
         length = length - 488;
-
 
         var scroll = $(this).scrollTop();
 
@@ -67,9 +63,7 @@ $('document').ready(function() {
         tlt = $('main .tutorials-like-this').outerHeight(true);
         bottom = (helpH + tlt);
 
-
         length = length - 488;
-
 
         scroll = $(this).scrollTop();
 

--- a/_includes/seo.html
+++ b/_includes/seo.html
@@ -23,5 +23,3 @@
 
 <!-- Favicon -->
     <link rel="shortcut icon" href="/images/plotly-ico.png?v=2">
-
-

--- a/_includes/social_share_bar.html
+++ b/_includes/social_share_bar.html
@@ -9,9 +9,7 @@
 
 <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script>
 
-
 <script src="https://apis.google.com/js/platform.js" async defer></script>
-
 
 <div class="share_bar">
     <div class="fb-like"  data-href="http://help.plot.ly/{{page.permalink}}" data-layout="button_count" data-action="like" data-show-faces="false" data-share="true"></div>

--- a/_layouts/connectors-tutorial-single_layout.html
+++ b/_layouts/connectors-tutorial-single_layout.html
@@ -4,7 +4,6 @@
         {% include google-tag-head.html %}
         {% include drift-tag.html %}
 
-
     <script async="" src="/browser-sync/browser-sync-client.2.11.1.js"></script>
     <!-- META TAGS -->
     {% include seo.html %}
@@ -18,7 +17,6 @@
     <link rel="stylesheet" type="text/css" href="/stylesheets/plotly_icons.css">
     <link href="//fonts.googleapis.com/css?family=Open+Sans:600,400,300,200|Inconsolata|Ubuntu+Mono:400,700"
           rel="stylesheet" type="text/css">
-
 
     <!-- Stylesheets -->
     <link rel="stylesheet" type="text/css" href="https://images.plot.ly/assets/css/normalize.css">
@@ -40,12 +38,10 @@
 <body data-spy="scroll" data-target=".watch" style="position:relative;">
         {% include google-tag-body.html %}
 
-
 <!--[if lt IE 10]>
 <p class="browserupgrade">You are using an <strong>outdated</strong> browser. Please <a href="http://browsehappy.com/">upgrade
     your browser</a> to improve your experience.</p>
 <![endif]-->
-
 
 <!-- Navigation -->
 {% include _new/_page-components/_header-main.html %}
@@ -150,7 +146,6 @@
                         </div>
                     </div>
 
-
                 {% for content in step.sub-steps %}
                 <p class="step--content">{{ content.copy | escape | markdownify }}</p>
                 {% if content.img %}
@@ -170,7 +165,6 @@
 {% include help-box.html %}
 
 {% include _new/_page-components/_footer-main.html %}
-
 
 <script src="//images.plot.ly/assets/js/ZeroClipboard.min.js"></script>
 <script src="/js/main.js"></script>

--- a/_layouts/connectors.html
+++ b/_layouts/connectors.html
@@ -21,11 +21,9 @@ title: Chart Studio Tutorials
     <link href="//fonts.googleapis.com/css?family=Open+Sans:600,400,300,200|Inconsolata|Ubuntu+Mono:400,700"
           rel="stylesheet" type="text/css">
 
-
     <!-- Stylesheets -->
     <link rel="stylesheet" type="text/css" href="https://images.plot.ly/assets/css/normalize.css">
     <link rel="stylesheet" type="text/css" href="{{site.stylesheet}}">
-
 
     <!--[if IE]-->
     <style>
@@ -43,12 +41,10 @@ title: Chart Studio Tutorials
 <body data-spy="scroll" data-target=".watch" style="position:relative;">
         {% include google-tag-body.html %}
 
-
 <!--[if lt IE 10]>
 <p class="browserupgrade">You are using an <strong>outdated</strong> browser. Please <a href="http://browsehappy.com/">upgrade
     your browser</a> to improve your experience.</p>
 <![endif]-->
-
 
 <!-- Navigation -->
 {% include _new/_page-components/_header-main.html %}

--- a/_layouts/excel-page.html
+++ b/_layouts/excel-page.html
@@ -8,7 +8,6 @@ title: Chart Studio Excel Tutorials
         {% include google-tag-head.html %}
         {% include drift-tag.html %}
 
-
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="chrome=1">
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
@@ -22,11 +21,9 @@ title: Chart Studio Excel Tutorials
     <link href="//fonts.googleapis.com/css?family=Open+Sans:600,400,300,200|Inconsolata|Ubuntu+Mono:400,700"
           rel="stylesheet" type="text/css">
 
-
     <!-- Stylesheets -->
     <link rel="stylesheet" type="text/css" href="https://images.plot.ly/assets/css/normalize.css">
     <link rel="stylesheet" type="text/css" href="{{site.stylesheet}}">
-
 
     <!--[if IE]-->
     <style>
@@ -42,12 +39,10 @@ title: Chart Studio Excel Tutorials
 <body data-spy="scroll" data-target=".watch" style="position:relative;">
         {% include google-tag-body.html %}
 
-
 <!--[if lt IE 10]>
 <p class="browserupgrade">You are using an <strong>outdated</strong> browser. Please <a href="http://browsehappy.com/">upgrade
     your browser</a> to improve your experience.</p>
 <![endif]-->
-
 
 <!-- Navigation -->
 {% include _new/_page-components/_header-main.html %}
@@ -483,19 +478,16 @@ title: Chart Studio Excel Tutorials
 </main>
 {% include help-box.html %}
 
-
 {% include _new/_page-components/_footer-main.html %}
 
 <script>
     var array = [];
-
 
     $('header.--section-header a').each(function (i, e) {
         array.push($(e).text());
     });
 
     $('*').not('p').prev('p').addClass('last');
-
 
     $(".--sidebar-list").html(array.map(function(value) {
         var hash = value.replace(/[^a-z0-9\s]/gi, '').replace(/[_\s]/g, '-').toLowerCase();

--- a/_layouts/excel-tutorial-single_layout.html
+++ b/_layouts/excel-tutorial-single_layout.html
@@ -4,7 +4,6 @@
         {% include google-tag-head.html %}
         {% include drift-tag.html %}
 
-
     <script async="" src="/browser-sync/browser-sync-client.2.11.1.js"></script>
     <!-- META TAGS -->
     {% include seo.html %}
@@ -18,7 +17,6 @@
     <link rel="stylesheet" type="text/css" href="/stylesheets/plotly_icons.css">
     <link href="//fonts.googleapis.com/css?family=Open+Sans:600,400,300,200|Inconsolata|Ubuntu+Mono:400,700"
           rel="stylesheet" type="text/css">
-
 
     <!-- Stylesheets -->
     <link rel="stylesheet" type="text/css" href="https://images.plot.ly/assets/css/normalize.css">
@@ -44,7 +42,6 @@
 <p class="browserupgrade">You are using an <strong>outdated</strong> browser. Please <a href="http://browsehappy.com/">upgrade
     your browser</a> to improve your experience.</p>
 <![endif]-->
-
 
 <!-- Navigation -->
 {% include _new/_page-components/_header-main.html %}
@@ -151,7 +148,6 @@
                         </div>
                     </div>
 
-
                 {% for content in step.sub-steps %}
                 <p class="step--content">{{ content.copy | escape | markdownify }}</p>
                 {% if content.img %}
@@ -171,7 +167,6 @@
 {% include help-box.html %}
 
 {% include _new/_page-components/_footer-main.html %}
-
 
 <script src="//images.plot.ly/assets/js/ZeroClipboard.min.js"></script>
 <script src="/js/main.js"></script>

--- a/_layouts/new_layout.html
+++ b/_layouts/new_layout.html
@@ -13,7 +13,6 @@
     <link rel="stylesheet" type="text/css" href="/stylesheets/plotly_icons.css">
     <link href="//fonts.googleapis.com/css?family=Open+Sans:600,400,300,200|Inconsolata|Ubuntu+Mono:400,700" rel="stylesheet" type="text/css">
 
-
     <!-- Stylesheets -->
     <link rel="stylesheet" type="text/css" href="/stylesheets/normalize.css">
     <link rel="stylesheet" type="text/css" href="/stylesheets/base.css">
@@ -29,12 +28,10 @@
   <body>
       {% include google-tag-body.html %}
 
-
   <div class="container smallcontainer">
     <div>
       <div>
         <section>
-
 
           {{ content }}
 

--- a/_layouts/search.html
+++ b/_layouts/search.html
@@ -8,7 +8,6 @@ title: Chart Studio Tutorials
         {% include google-tag-head.html %}
         {% include drift-tag.html %}
 
-
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="chrome=1">
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
@@ -22,11 +21,9 @@ title: Chart Studio Tutorials
     <link href="//fonts.googleapis.com/css?family=Open+Sans:600,400,300,200|Inconsolata|Ubuntu+Mono:400,700"
           rel="stylesheet" type="text/css">
 
-
     <!-- Stylesheets -->
     <link rel="stylesheet" type="text/css" href="https://images.plot.ly/assets/css/normalize.css">
     <link rel="stylesheet" type="text/css" href="{{site.stylesheet}}">
-
 
     <!--[if IE]-->
     <style>
@@ -50,7 +47,6 @@ title: Chart Studio Tutorials
 <p class="browserupgrade">You are using an <strong>outdated</strong> browser. Please <a href="http://browsehappy.com/">upgrade
     your browser</a> to improve your experience.</p>
 <![endif]-->
-
 
 <!-- Navigation -->
 {% include _new/_page-components/_header-main.html %}
@@ -80,7 +76,6 @@ title: Chart Studio Tutorials
             </li>
             <li class="--breadcrumb-item --current"><span>Chart Studio Tutorials</span></li>
         </ul>
-
 
         <div class="--fork">
 

--- a/_layouts/single.html
+++ b/_layouts/single.html
@@ -17,11 +17,9 @@
     <link href="//fonts.googleapis.com/css?family=Open+Sans:600,400,300,200|Inconsolata|Ubuntu+Mono:400,700"
           rel="stylesheet" type="text/css">
 
-
     <!-- Stylesheets -->
     <link rel="stylesheet" type="text/css" href="https://images.plot.ly/assets/css/normalize.css">
     <link rel="stylesheet" type="text/css" href="{{site.stylesheet}}">
-
 
     <!--[if IE]-->
     <style>
@@ -42,7 +40,6 @@
 <p class="browserupgrade">You are using an <strong>outdated</strong> browser. Please <a href="http://browsehappy.com/">upgrade
     your browser</a> to improve your experience.</p>
 <![endif]-->
-
 
 <!-- Navigation -->
 {% include _new/_page-components/_header-main.html %}
@@ -162,15 +159,12 @@
 
 <script>
 
-
-
     var array = [];
 
     $('.tutorial-content :header:not(h6)').each(function (i, e) {
 
         var item = $(e);
         var itemText = item.text();
-
 
         var hash = itemText.replace(/[^a-z0-9\s]/gi, '').replace(/[_\s]/g, '-').replace(/^-+|-+$/g, '').toLowerCase();
         console.log(hash);
@@ -185,9 +179,7 @@
         return('<li class="--sidebar-item"><a href="#' + hash + '">' + value.replace(/[^a-z0-9\s:\.]/gi, '') + '</a></li>');
     }).join(""));
 
-
 //        $(".tutorial-content :header:not(h6)").append( "\<div class=\"icon copy\" data-tooltip=\"Click to copy direct link\"><svg style=\"width:24px;height:24px\" viewBox=\"0 0 24 24\"><path fill=\"#000000\" d=\"M10.59,13.41C11,13.8 11,14.44 10.59,14.83C10.2,15.22 9.56,15.22 9.17,14.83C7.22,12.88 7.22,9.71 9.17,7.76V7.76L12.71,4.22C14.66,2.27 17.83,2.27 19.78,4.22C21.73,6.17 21.73,9.34 19.78,11.29L18.29,12.78C18.3,11.96 18.17,11.14 17.89,10.36L18.36,9.88C19.54,8.71 19.54,6.81 18.36,5.64C17.19,4.46 15.29,4.46 14.12,5.64L10.59,9.17C9.41,10.34 9.41,12.24 10.59,13.41M13.41,9.17C13.8,8.78 14.44,8.78 14.83,9.17C16.78,11.12 16.78,14.29 14.83,16.24V16.24L11.29,19.78C9.34,21.73 6.17,21.73 4.22,19.78C2.27,17.83 2.27,14.66 4.22,12.71L5.71,11.22C5.7,12.04 5.83,12.86 6.11,13.65L5.64,14.12C4.46,15.29 4.46,17.19 5.64,18.36C6.81,19.54 8.71,19.54 9.88,18.36L13.41,14.83C14.59,13.66 14.59,11.76 13.41,10.59C13,10.2 13,9.56 13.41,9.17Z\"/> </svg> </div>");
-
 
     $("a[href^='#']").on('click', function(event) {
         var target;

--- a/_layouts/single_new.html
+++ b/_layouts/single_new.html
@@ -3,7 +3,6 @@
 <body data-spy="scroll">
         {% include google-tag-body.html %}
 
-
 <!--[if lt IE 10]>
 <p class="browserupgrade">You are using an <strong>outdated</strong> browser. Please <a href="http://browsehappy.com/">upgrade
     your browser</a> to improve your experience.</p>

--- a/_layouts/support.html
+++ b/_layouts/support.html
@@ -18,7 +18,6 @@
     <link href="//fonts.googleapis.com/css?family=Open+Sans:600,400,300,200|Inconsolata|Ubuntu+Mono:400,700"
           rel="stylesheet" type="text/css">
 
-
     <!-- Stylesheets -->
     <link rel="stylesheet" type="text/css" href="https://images.plot.ly/assets/css/normalize.css">
     <link rel="stylesheet" type="text/css" href="{{site.stylesheet}}">
@@ -57,7 +56,6 @@
 <p class="browserupgrade">You are using an <strong>outdated</strong> browser. Please <a href="http://browsehappy.com/">upgrade
     your browser</a> to improve your experience.</p>
 <![endif]-->
-
 
 <!-- Navigation -->
 {% include _new/_page-components/_header-main.html %}
@@ -126,7 +124,6 @@
 </main>
 
 {% include _new/_page-components/_footer-main.html %}
-
 
 <script src="//images.plot.ly/assets/js/ZeroClipboard.min.js"></script>
 <script src="/js/main.js"></script>

--- a/_layouts/tutorial-single_layout.html
+++ b/_layouts/tutorial-single_layout.html
@@ -18,7 +18,6 @@
     <link href="//fonts.googleapis.com/css?family=Open+Sans:600,400,300,200|Inconsolata|Ubuntu+Mono:400,700"
           rel="stylesheet" type="text/css">
 
-
     <!-- Stylesheets -->
     <link rel="stylesheet" type="text/css" href="https://images.plot.ly/assets/css/normalize.css">
     <link rel="stylesheet" type="text/css" href="{{site.stylesheet}}">
@@ -43,7 +42,6 @@
 <p class="browserupgrade">You are using an <strong>outdated</strong> browser. Please <a href="http://browsehappy.com/">upgrade
     your browser</a> to improve your experience.</p>
 <![endif]-->
-
 
 <!-- Navigation -->
 {% include _new/_page-components/_header-main.html %}
@@ -150,7 +148,6 @@
                         </div>
                     </div>
 
-
                 {% for content in step.sub-steps %}
                 <p class="step--content">{{ content.copy | escape | markdownify }}</p>
                 {% if content.img %}
@@ -170,7 +167,6 @@
 {% include help-box.html %}
 
 {% include _new/_page-components/_footer-main.html %}
-
 
 <script src="//images.plot.ly/assets/js/ZeroClipboard.min.js"></script>
 <script src="/js/main.js"></script>

--- a/_layouts/tutorial.single.html
+++ b/_layouts/tutorial.single.html
@@ -4,7 +4,6 @@
         {% include google-tag-head.html %}
         {% include drift-tag.html %}
 
-
     <script async="" src="/browser-sync/browser-sync-client.2.11.1.js"></script>
     <!-- META TAGS -->
     {% include seo.html %}
@@ -18,7 +17,6 @@
     <link rel="stylesheet" type="text/css" href="/stylesheets/plotly_icons.css">
     <link href="//fonts.googleapis.com/css?family=Open+Sans:600,400,300,200|Inconsolata|Ubuntu+Mono:400,700"
           rel="stylesheet" type="text/css">
-
 
     <!-- Stylesheets -->
     <link rel="stylesheet" type="text/css" href="https://images.plot.ly/assets/css/normalize.css">
@@ -44,7 +42,6 @@
 <p class="browserupgrade">You are using an <strong>outdated</strong> browser. Please <a href="http://browsehappy.com/">upgrade
     your browser</a> to improve your experience.</p>
 <![endif]-->
-
 
 <!-- Navigation -->
 {% include _new/_page-components/_header-main.html %}
@@ -151,7 +148,6 @@
                         </div>
                     </div>
 
-
                 {% for content in step.sub-steps %}
                 <p class="step--content">{{ content.copy | escape | markdownify }}</p>
                 {% if content.img %}
@@ -171,7 +167,6 @@
 {% include help-box.html %}
 
 {% include _new/_page-components/_footer-main.html %}
-
 
 <script src="//images.plot.ly/assets/js/ZeroClipboard.min.js"></script>
 <script src="/js/main.js"></script>

--- a/_layouts/tutorials.html
+++ b/_layouts/tutorials.html
@@ -8,7 +8,6 @@ title: Chart Studio Tutorials
         {% include google-tag-head.html %}
         {% include drift-tag.html %}
 
-
     {% assign sorted = site.posts | sort: "order" %}
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="chrome=1">
@@ -23,11 +22,9 @@ title: Chart Studio Tutorials
     <link href="//fonts.googleapis.com/css?family=Open+Sans:600,400,300,200|Inconsolata|Ubuntu+Mono:400,700"
           rel="stylesheet" type="text/css">
 
-
     <!-- Stylesheets -->
     <link rel="stylesheet" type="text/css" href="https://images.plot.ly/assets/css/normalize.css">
     <link rel="stylesheet" type="text/css" href="{{site.stylesheet}}">
-
 
     <!--[if IE]-->
     <style>
@@ -49,7 +46,6 @@ title: Chart Studio Tutorials
 <p class="browserupgrade">You are using an <strong>outdated</strong> browser. Please <a href="http://browsehappy.com/">upgrade
     your browser</a> to improve your experience.</p>
 <![endif]-->
-
 
 <!-- Navigation -->
 {% include _new/_page-components/_header-main.html %}
@@ -264,7 +260,6 @@ title: Chart Studio Tutorials
 
                         </li>
 
-
                         {% endif %}
                         {%- endfor -%}
                     </ul>
@@ -301,7 +296,6 @@ title: Chart Studio Tutorials
                         <li style="background-image: url({{page.imageurl}});" class="--grid-item">
                             <a href="{{page.permalink}}">
 
-
                                 <!--<a href="{{page.permalink}}">-->
                                 <div class="--item-meta"><span>{{page.title}}</span></div>
                                 <div class="--item-image">
@@ -312,7 +306,6 @@ title: Chart Studio Tutorials
                             {% endif %}
 
                         </li>
-
 
                         {% endif %}
                         {%- endfor -%}
@@ -350,7 +343,6 @@ title: Chart Studio Tutorials
                         <li style="background-image: url({{page.imageurl}});" class="--grid-item">
                             <a href="{{page.permalink}}">
 
-
                                 <!--<a href="{{page.permalink}}">-->
                                 <div class="--item-meta"><span>{{page.title}}</span></div>
                                 <div class="--item-image">
@@ -361,7 +353,6 @@ title: Chart Studio Tutorials
                             {% endif %}
 
                         </li>
-
 
                         {% endif %}
                         {%- endfor -%}
@@ -399,7 +390,6 @@ title: Chart Studio Tutorials
                         <li style="background-image: url({{page.imageurl}});" class="--grid-item">
                             <a href="{{page.permalink}}">
 
-
                                 <!--<a href="{{page.permalink}}">-->
                                 <div class="--item-meta"><span>{{page.title}}</span></div>
                                 <div class="--item-image">
@@ -410,7 +400,6 @@ title: Chart Studio Tutorials
                             {% endif %}
 
                         </li>
-
 
                         {% endif %}
                         {%- endfor -%}
@@ -448,7 +437,6 @@ title: Chart Studio Tutorials
                         <li style="background-image: url({{page.imageurl}});" class="--grid-item">
                             <a href="{{page.permalink}}">
 
-
                                 <!--<a href="{{page.permalink}}">-->
                                 <div class="--item-meta"><span>{{page.title}}</span></div>
                                 <div class="--item-image">
@@ -459,7 +447,6 @@ title: Chart Studio Tutorials
                             {% endif %}
 
                         </li>
-
 
                         {% endif %}
                         {%- endfor -%}
@@ -497,7 +484,6 @@ title: Chart Studio Tutorials
                         <li style="background-image: url({{page.imageurl}});" class="--grid-item">
                             <a href="{{page.permalink}}">
 
-
                                 <!--<a href="{{page.permalink}}">-->
                                 <div class="--item-meta"><span>{{page.title}}</span></div>
                                 <div class="--item-image">
@@ -508,7 +494,6 @@ title: Chart Studio Tutorials
                             {% endif %}
 
                         </li>
-
 
                         {% endif %}
                         {%- endfor -%}
@@ -555,7 +540,6 @@ title: Chart Studio Tutorials
 
                         </li>
 
-
                         {% endif %}
                         {% endfor %}
                     </ul>
@@ -592,7 +576,6 @@ title: Chart Studio Tutorials
                         <li style="background-image: url({{page.imageurl}});" class="--grid-item">
                             <a href="{{page.permalink}}">
 
-
                                 <!--<a href="{{page.permalink}}">-->
                                 <div class="--item-meta"><span>{{page.title}}</span></div>
                                 <div class="--item-image">
@@ -603,7 +586,6 @@ title: Chart Studio Tutorials
                             {% endif %}
 
                         </li>
-
 
                         {% endif %}
                         {%- endfor -%}
@@ -641,7 +623,6 @@ title: Chart Studio Tutorials
                         <li style="background-image: url({{page.imageurl}});" class="--grid-item">
                             <a href="{{page.permalink}}">
 
-
                                 <!--<a href="{{page.permalink}}">-->
                                 <div class="--item-meta"><span>{{page.title}}</span></div>
                                 <div class="--item-image">
@@ -652,7 +633,6 @@ title: Chart Studio Tutorials
                             {% endif %}
 
                         </li>
-
 
                         {% endif %}
                         {%- endfor -%}
@@ -691,7 +671,6 @@ title: Chart Studio Tutorials
                         <li style="background-image: url({{page.imageurl}});" class="--grid-item">
                             <a href="{{page.permalink}}">
 
-
                                 <!--<a href="{{page.permalink}}">-->
                                 <div class="--item-meta"><span>{{page.title}}</span></div>
                                 <div class="--item-image">
@@ -702,7 +681,6 @@ title: Chart Studio Tutorials
                             {% endif %}
 
                         </li>
-
 
                         {% endif %}
                         {%- endfor -%}
@@ -746,7 +724,6 @@ title: Chart Studio Tutorials
                             {% endif %}
 
                         </li>
-
 
                         {% endif %}
                         {%- endfor -%}

--- a/_layouts/two_column_layout.html
+++ b/_layouts/two_column_layout.html
@@ -5,7 +5,6 @@
       {% include drift-tag.html %}
       <script async="" src="/browser-sync/browser-sync-client.2.11.1.js"></script>
 
-
     <!-- META TAGS -->
     {% include seo.html %}
 
@@ -21,7 +20,6 @@
     <link rel="stylesheet" type="text/css" href="/stylesheets/modules.css">
     <link rel="stylesheet" type="text/css" href="/stylesheets/state.css">
     <link rel="stylesheet" type="text/css" href="/stylesheets/two_col_stylesheet.css">
-
 
   </head>
   {% include new_header.html %}

--- a/index.html
+++ b/index.html
@@ -8,38 +8,24 @@ title: Plotly Help Center
     {% include google-tag-head.html %}
     {% include drift-tag.html %}
 
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="viewport" content="width=device-width, initial-scale=1">
 
     <!-- Stylesheets -->
-    <link
-      rel="stylesheet"
-      type="text/css"
-      href="https://images.plot.ly/assets/css/normalize.css"
-    />
-    <link rel="stylesheet" type="text/css" href="{{ site.stylesheet }}" />
+    <link rel="stylesheet" type="text/css" href="https://images.plot.ly/assets/css/normalize.css">
+    <link rel="stylesheet" type="text/css" href="{{ site.stylesheet }}">
     <!-- Fonts -->
-    <link
-      rel="stylesheet"
-      href="https://maxcdn.bootstrapcdn.com/font-awesome/4.4.0/css/font-awesome.min.css"
-    />
-    <link
-      rel="stylesheet"
-      type="text/css"
-      href="/stylesheets/plotly_icons.css"
-    />
-    <link href="https://fonts.googleapis.com/css?family=Asap&display=swap" rel="stylesheet"/>
+    <link rel="stylesheet"
+      href="https://maxcdn.bootstrapcdn.com/font-awesome/4.4.0/css/font-awesome.min.css">
+    <link rel="stylesheet" type="text/css" href="/stylesheets/plotly_icons.css">
+    <link href="https://fonts.googleapis.com/css?family=Asap&display=swap" rel="stylesheet">
 
     <!-- Icon -->
-    <link
-      rel="shortcut icon"
-      href="/images/plotly-ico.png?v=2"
-      type="image/x-icon"
-    />
+    <link rel="shortcut icon" href="/images/plotly-ico.png?v=2" type="image/x-icon">
 
     <!-- META TAGS -->
     {% include _new/_page-components/_seo.html %}
     <script src="//ajax.googleapis.com/ajax/libs/jquery/2.2.0/jquery.min.js"></script>
-    <meta name="theme-color" content="#447bdc" />
+    <meta name="theme-color" content="#447bdc">
   </head>
 
   <body>
@@ -69,8 +55,7 @@ title: Plotly Help Center
                     <div class="category-img">
                       <img
                         src="https://images.plot.ly/logo/new-branding/plotly-logomark.png"
-                        alt="Plotly logo"
-                      />
+                        alt="Plotly logo">
                     </div>
                     <div class="category-meta">
                       <h2>Chart Studio</h2>
@@ -85,12 +70,10 @@ title: Plotly Help Center
                     <div class="category-img">
                       <img
                         src="https://s3-us-west-1.amazonaws.com/plotly-tutorials/background-images/python-logo.png"
-                        alt="python logo"
-                      />
+                        alt="Python logo">
                     </div>
                     <div class="category-meta">
                       <h2>Open Source Graphing Libraries</h2>
-
                       <p>
                         Engineers and data scientists using Python, R, Matlab or
                         JavaScript.
@@ -104,7 +87,7 @@ title: Plotly Help Center
                 <a href="https://dash.plot.ly/">
                   <div class="category-wrap">
                     <div class="category-img">
-                      <img src="/images/dash.png" alt="Dash logo" />
+                      <img src="/images/dash.png" alt="Dash logo">
                     </div>
                     <div class="category-meta">
                       <h2>Dash</h2>
@@ -122,8 +105,7 @@ title: Plotly Help Center
                     <div class="category-img">
                       <img
                         src="https://help.plot.ly/static/images/falcon/logos/query-from-falcon.png"
-                        alt="Falcon logo"
-                      />
+                        alt="Falcon logo">
                     </div>
 
                     <div class="category-meta">

--- a/stylesheets/state.css
+++ b/stylesheets/state.css
@@ -9,7 +9,7 @@
 .no_deco{
 	text-decoration: none;}
 .hoverlight:hover{
-	opacity= 0.5;}
+	opacity: 0.5;}
 .wide{
 	width: 100%;}
 .no-margin{


### PR DESCRIPTION
https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Bundler/OrderedGems

Standardize the `meta`, `link`, and  `img` HTML tags to use HTML5 syntax.

Fix case of Python. 
Fix CSS. 
Remove whitespace.
Fix `br` tag.