### PR TITLE
inlining falcon and slide decks download links 

### DIFF
--- a/_posts/dashboards-spectacle/2018-05-03-slide-decks.md
+++ b/_posts/dashboards-spectacle/2018-05-03-slide-decks.md
@@ -19,18 +19,20 @@ steps:
 
  - title: Get Started
    sub-steps:
-    - copy: "The Slide Deck Editor is a standalone desktop application that connects to your Chart Studio account. If you haven't already, download [Slide Deck Editor](https://plot.ly/online-presentation-tool/)."
-      img: "![Download Editor](../static/images/slide-decks/download.PNG)"
+    - copy: "The Slide Deck Editor is a standalone desktop application that connects to your Chart Studio account. If you haven't already, download Slide Deck Editor."
+    - copy: "[Download For Windows](https://images-plotly.imgix.net/spectacle-editor/Spectacle.Editor.Setup.0.1.4.exe){: .typeform-share}"
+    - copy: "[Download For Mac](https://github.com/plotly/spectacle-editor/releases/download/v0.1.6/Spectacle.Editor-0.1.6.dmg)"
 
  - title: Sign In
    sub-steps:
     - copy: "Once you have downloaded and installed the Slide Decks Editor, click 'SIGN IN TO PLOT.LY' situated in the top-right of the editor interface. In the pop-up modal enter your Chart Studio username and password."
       img: "![Sign In Modal](../static/images/slide-decks/sign-in.PNG)"
 
- - title: Use Templates
+ - title: Use A Template
    sub-steps:
-    - copy: "Navigating back to the Slide Deck Editor [landing page]](https://plot.ly/online-presentation-tool/), you can click to view or download business, science, or research styled templates. Alternatively, you can visit the dedicated template account - [Slide Template](https://plot.ly/~slide_templates/#/) - for more options"
-      img: "![Download Template](../static/images/slide-decks/download-template.PNG)"
+    - copy: "Plotly provides templates to help you start building your presentations. You view or download business, science, or research styled templates by visiting the dedicated template account - [Slide Template](https://plot.ly/~slide_templates/#/). To continue with this tutorial, downlaod the example template."
+    - copy: "[Download Template](https://plot.ly/~slide_templates/6.json)"
+    - copy: "[Preview Template](https://plot.ly/~slide_templates/6.embed#/?_k=18961w)"
     - copy: "After you click download, a JSON formatted file will be download to your local machine. Next, open the Slide Deck Editor application and click 'File', 'Open', and then select the downloaded JSON file. Now, you ought to see something like the below image."
       img: "![Downloaded Template](../static/images/slide-decks/downloaded-template.PNG)"
 

--- a/_posts/falcon/2016-12-30-personal-user.md
+++ b/_posts/falcon/2016-12-30-personal-user.md
@@ -16,8 +16,9 @@ steps:
     - copy: "Falcon is a free, [open-source](https://github.com/plotly/plotly-database-connector/) SQL editor with inline data visualization. With Falcon you can connect to your database in the Connection tab, run SQL queries in the Query tab, then export your results as a CSV or open them in the [Chart Studio](https://plot.ly/create) to unlock the full power of Plotly graphs. Optionally, you can use Falcon as a middleman between plot.ly and your database - so that when your database updates, your charts and dashboards update as well. Currently, Falcon supports connections to RedShift, MySQL, PostgreSQL, IBM DB2, Impala, MS SQL, and SQLite."
  - title: Download the App
    sub-steps:
-    - copy: "If you haven't yet, download Falcon SQL Client from the [Falcon product page](https://plot.ly/free-sql-client-download/) to get started! Upon clicking on the download button for either Mac or Windows distribution, a file should be added to your Downloads folder."
-      img: "![Download](/static/images/falcon/personal/download.png)"
+    - copy: "If you haven't yet, download Falcon SQL Client to get started! Upon clicking on the download link for either Mac or Windows distribution, a file should be added to your Downloads folder."
+    - copy: "[Download For Windows](https://github.com/plotly/falcon/releases/download/v4.1.0/win-falcon-v4.1.0.zip)"
+    - copy: "[Download For Mac](https://github.com/plotly/falcon/releases/download/v4.1.0/mac-falcon-v4.1.0.zip)"
  - title: Install Falcon (Windows)
    sub-steps:
     - copy: "Visit your Downloads folder and double click on the application executable to unzip."

--- a/_posts/fundamentals/2016-06-23-how-to-enter-data.md
+++ b/_posts/fundamentals/2016-06-23-how-to-enter-data.md
@@ -37,7 +37,7 @@ steps:
 
  - title: Option 4 - Import Data via Falcon SQL Client
    sub-steps:
-    - copy: "You can import data by connecting to your SQL database through the [Falcon SQL client](https://plot.ly/free-sql-client-download/). To learn more about how to connect your databases to your chart via Falcon, check out [this](https://help.plot.ly/database-connectors/) section."
+    - copy: "You can import data by connecting to your SQL database through the [Falcon SQL client](https://help.plot.ly/database-connectors/personal-login/). To learn more about how to connect your databases to your chart via Falcon, check out [this](https://help.plot.ly/database-connectors/personal-login/) section."
       img: "![Import from SQL](../static/images/import-data/import_sql.png)"
 
  - title: Option 5 - Import Data from the Examples


### PR DESCRIPTION
The purpose of this PR is to inline download links to Falcon and the Slide Deck editor, as the pages that currently host the download links will be decommissioned in the near future. 

closes https://github.com/plotly/plotly.github.io/issues/522