### PR TITLE
Add a lang attribute to the html start tag and set it to 'en'.

### DIFF
--- a/404.html
+++ b/404.html
@@ -3,7 +3,7 @@ title: 404 Page
 ---
 
 <!DOCTYPE html>
-<html>
+<html lang="en">
     <head>
         {% include google-tag-head.html %}
         {% include drift-tag.html %}

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     {% include google-tag-head.html %}
     {% include drift-tag.html %}

--- a/_layouts/connectors-tutorial-single_layout.html
+++ b/_layouts/connectors-tutorial-single_layout.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
         {% include google-tag-head.html %}
         {% include drift-tag.html %}

--- a/_layouts/connectors.html
+++ b/_layouts/connectors.html
@@ -3,7 +3,7 @@ title: Chart Studio Tutorials
 ---
 
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
         {% include google-tag-head.html %}
         {% include drift-tag.html %}

--- a/_layouts/excel-page.html
+++ b/_layouts/excel-page.html
@@ -3,7 +3,7 @@ title: Chart Studio Excel Tutorials
 ---
 
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
         {% include google-tag-head.html %}
         {% include drift-tag.html %}

--- a/_layouts/excel-tutorial-single_layout.html
+++ b/_layouts/excel-tutorial-single_layout.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
         {% include google-tag-head.html %}
         {% include drift-tag.html %}

--- a/_layouts/new_layout.html
+++ b/_layouts/new_layout.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
 
       {% include google-tag-head.html %}

--- a/_layouts/search.html
+++ b/_layouts/search.html
@@ -3,7 +3,7 @@ title: Chart Studio Tutorials
 ---
 
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
         {% include google-tag-head.html %}
         {% include drift-tag.html %}

--- a/_layouts/single.html
+++ b/_layouts/single.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
         {% include google-tag-head.html %}
         {% include drift-tag.html %}

--- a/_layouts/support.html
+++ b/_layouts/support.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
         {% include google-tag-head.html %}
         {% include drift-tag.html %}

--- a/_layouts/tutorial-single_layout.html
+++ b/_layouts/tutorial-single_layout.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
         {% include google-tag-head.html %}
         {% include drift-tag.html %}

--- a/_layouts/tutorial.html
+++ b/_layouts/tutorial.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   {% include header.html %}
 
   <body>

--- a/_layouts/tutorial.single.html
+++ b/_layouts/tutorial.single.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
         {% include google-tag-head.html %}
         {% include drift-tag.html %}

--- a/_layouts/tutorials.html
+++ b/_layouts/tutorials.html
@@ -3,7 +3,7 @@ title: Chart Studio Tutorials
 ---
 
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
         {% include google-tag-head.html %}
         {% include drift-tag.html %}

--- a/_layouts/two_column_layout.html
+++ b/_layouts/two_column_layout.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
       {% include google-tag-head.html %}
       {% include drift-tag.html %}

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@ title: Plotly Help Center
 ---
 
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     {% include google-tag-head.html %}
     {% include drift-tag.html %}


### PR DESCRIPTION
The HTML lang attribute can be used to declare the language of a Web page or a portion of a Web page. This is meant to assist search engines and browsers.

According to the W3C recommendation you should declare the primary language for each Web page with the lang attribute inside the <html> tag