### PR TITLE
remove some usage of bounty from security.md

### DIFF
--- a/_posts/fundamentals/2016-08-02-security.md
+++ b/_posts/fundamentals/2016-08-02-security.md
@@ -2,7 +2,7 @@
 permalink: /security/
 title: Plotly Security
 layout: single_new
-title: Plotly Security Vulnerability Bounty Program
+title: Plotly Security & Vulnerability Program
 support: true
 ---
 
@@ -71,7 +71,7 @@ Subject to the restrictions outlined elsewhere in this document, Plotly pays bou
 
 ## Additional legal terms
 
-By participating in Plotly's Bug Bounty program (the "Program"), you acknowledge that you have read and agree to Plotly's [terms of service](https://plot.ly/terms-of-service/) as well as the following:
+By participating in Plotly's Security & Vulnerability Program (the "Program"), you acknowledge that you have read and agree to Plotly's [terms of service](https://plot.ly/terms-of-service/) as well as the following:
 
 * You’re not participating from a country against which the United States has issued export sanctions or other trade restrictions, including Cuba, Iran, North Korea, the Sudan and Syria.
 * Your participation in the Program will not violate any law applicable to you, or disrupt or compromise any data that is not your own.


### PR DESCRIPTION
@nicolaskruchten @scjody 
Removed the word "bounty" from headline usage and also usage in legal statement to make the "Program" name match the headline title.