### PR TITLE
Add Playground & Replicated Admin into list of scopes

### DIFF
--- a/_posts/fundamentals/2016-08-02-security.md
+++ b/_posts/fundamentals/2016-08-02-security.md
@@ -63,6 +63,8 @@ In investigating security issues, we ask that:
 Subject to the restrictions outlined elsewhere in this document, Plotly pays bounties for issues in the following scopes:
 
 * Issues affecting the public [Dash App Gallery](https://dash-gallery.plotly.host/), including the ability to permanently modify any running app or its settings.
+* Issues affecting the public [Dash App Playground](https://dash-playground.plotly.host/), including the ability to permanently modify any running app or its settings or gain access to unauthorized views (/Manager, /Portal).
+* Access to the Dash App [Gallery Admin Console](https://gallery.plotly.host:8800/) or the [Playground Admin Console](https://playground.plotly.host:8800/)
 * Issues affecting the confidentiality of user data or security of user accounts in the customer-hosted version of [Dash Enterprise](https://plot.ly/dash/)
 * All issues affecting confidentiality of user data or security of user accounts on [Chart Studio Cloud](https://plot.ly/), excluding test or staging servers unless real user data is exposed.
 * Issues in any other service running on a `plot.ly` subdomain that could be used to attack Chart Studio Cloud.


### PR DESCRIPTION
Ok if I get a dancer on adding 
- https://dash-playground.plotly.host/
- https://gallery.plotly.host:8800/
- https://playground.plotly.host:8800/

then I'll also add these Scopes to our Private HackerOne program.