### PR TITLE
remove chart studio from security program

### DIFF
--- a/_posts/fundamentals/2016-08-02-security.md
+++ b/_posts/fundamentals/2016-08-02-security.md
@@ -6,8 +6,9 @@ title: Plotly Security & Vulnerability Program
 support: true
 ---
 
+**Update 05.04.2023:** We are no longer accepting security reports for Chart Studio. Please direct all security investigations to our Dash Enterprise product. A demo instance of this offering can be found here: https://sales-demo.plotly.com.
 
-Plotly welcomes reports of serious security issues that substantially affect the confidentiality or integrity of user data in Dash Enterprise, Chart Studio Enterprise, and Chart Studio Cloud, as well as serious security issues that affect Dash Apps hosted on Dash Enterprise. If you believe you have found a serious security vulnerability, please email <security@plot.ly> with steps to reproduce the problem. Please allow up to 24 hours for an initial response, or more on weekends.
+Plotly welcomes reports of serious security issues that substantially affect the confidentiality or integrity of user data in Dash Enterprise, as well as serious security issues that affect Dash Apps hosted on Dash Enterprise. If you believe you have found a serious security vulnerability, please email <security@plot.ly> with steps to reproduce the problem.
 
 [Plotly Security Advisories](http://help.plot.ly/security-advisories/) have their own page.
 

--- a/_posts/fundamentals/2016-08-02-security.md
+++ b/_posts/fundamentals/2016-08-02-security.md
@@ -6,7 +6,8 @@ title: Plotly Security & Vulnerability Program
 support: true
 ---
 
-**Update 05.04.2023:** We are no longer accepting security reports for Chart Studio. Please direct all security investigations to our Dash Enterprise product. A demo instance of this offering can be found here: https://sales-demo.plotly.com.
+**Update 05.04.2023:** We are no longer accepting security reports for Chart Studio. Please direct all security investigations to our open source packages (https://github.com/plotly) and our Dash Enterprise product. A demo instance of our enterprise offering can be found here: https://sales-demo.plotly.com.
+
 
 Plotly welcomes reports of serious security issues that substantially affect the confidentiality or integrity of user data in Dash Enterprise, as well as serious security issues that affect Dash Apps hosted on Dash Enterprise. If you believe you have found a serious security vulnerability, please email <security@plot.ly> with steps to reproduce the problem.
 


### PR DESCRIPTION
Resolves: https://github.com/plotly/dekn/issues/4537

FYI @alexcjohnson @x3rus @jingningzhang1 could I get a review of these changes? This was something that was discussed a few months back. Happy to provide more context as needed. 

